### PR TITLE
Add new OTP releases to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: erlang
 otp_release:
+  - 18.2.1
+  - 18.1
+  - 18.0
+  - 17.5
+  - R16B03
   - R16B
   - R15B02
   - R15B01


### PR DESCRIPTION
Releases added: 18.2.1, 18.1, 18.0, 17.5 and R16B03
